### PR TITLE
Fix for edge cases in to_json() function argument checking

### DIFF
--- a/lib/JSON.pm
+++ b/lib/JSON.pm
@@ -136,7 +136,10 @@ sub objToJson {
 # INTERFACES
 
 sub to_json ($@) {
-    if ( ref($_[0]) eq 'JSON' or $_[0] eq 'JSON' ) {
+    if (
+        ref($_[0]) eq 'JSON'
+        or (@_ > 2 and $_[0] eq 'JSON')
+    ) {
         Carp::croak "to_json should not be called as a method.";
     }
     my $json = new JSON;


### PR DESCRIPTION
This is the fix for https://rt.cpan.org/Public/Bug/Display.html?id=68359 issue.

I'm not sure where to put tests, there are too many test files, sorry :)
