### PR TITLE
fixed t/19_incr.t on perl >= 5.17.10 (wyant, rt#84154)

### DIFF
--- a/Changes
+++ b/Changes
@@ -23,6 +23,7 @@ They are JSNO::backportPP. So JSON.pm should work as it did at all!
 --------------------------------------------------------------------------
 
 2.54
+        - fixed t/19_incr.t on perl >= 5.17.10 (wyant, rt#84154)
 	- enhanced documents (Thanks to Justin Hunter and Olof Johansson)
 	- changed backend module loading for overloaded object behavior
 	                                        (reported by tokuhirom)

--- a/t/19_incr.t
+++ b/t/19_incr.t
@@ -34,10 +34,10 @@ sub splitter {
 
 
 
-splitter +JSON->new              , '  ["x\\"","\\u1000\\\\n\\nx",1,{"\\\\" :5 , "": "x"}]';
-splitter +JSON->new              , '[ "x\\"","\\u1000\\\\n\\nx" , 1,{"\\\\ " :5 , "": " x"} ] ';
-splitter +JSON->new->allow_nonref, '"test"';
-splitter +JSON->new->allow_nonref, ' "5" ';
+splitter +JSON->new->canonical   , '  ["x\\"","\\u1000\\\\n\\nx",1,{"\\\\" :5 , "": "x"}]';
+splitter +JSON->new->canonical   , '[ "x\\"","\\u1000\\\\n\\nx" , 1,{"\\\\ " :5 , "": " x"} ] ';
+splitter +JSON->new->allow_nonref->canonical, '"test"';
+splitter +JSON->new->allow_nonref->canonical, ' "5" ';
 
 
 


### PR DESCRIPTION
Hi, I made a pull request so you can integrate the patch in this RT easier.

https://rt.cpan.org/Public/Bug/Display.html?id=84154
