### PR TITLE
$json->is_xs() fails

### DIFF
--- a/t/is.t
+++ b/t/is.t
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+use Test::More;
+BEGIN { plan tests => 2 };
+
+BEGIN {
+    use_ok('JSON');
+}
+
+my $json = JSON->new();
+ok (defined ($json->is_pp()), '$json->is_pp()');
+ok (defined ($json->is_xs()), '$json->is_xs()');
+


### PR DESCRIPTION
Actually the object version of both is_xs() and is_pp() fail. I wrote a simple test script, "is.t", that tests  is_xs() and is_pp().
