### PR TITLE
CPAN-PR challenge january: fix bug RT#90319

### DIFF
--- a/lib/JSON/backportPP.pm
+++ b/lib/JSON/backportPP.pm
@@ -369,7 +369,8 @@ sub allow_bigint {
             if ( OLD_PERL ) { utf8::decode($k) } # key for Perl 5.6 / be optimized
             push @res, string_to_json( $self, $k )
                           .  $del
-                          . ( $self->object_to_json( $obj->{$k} ) || $self->value_to_json( $obj->{$k} ) );
+                          . do { my $from_obj = $self->object_to_json( $obj->{$k} );
+                                 defined $from_obj ? $from_obj : $self->value_to_json( $obj->{$k} ) };
         }
 
         --$depth;
@@ -389,7 +390,8 @@ sub allow_bigint {
         my ($pre, $post) = $indent ? $self->_up_indent() : ('', '');
 
         for my $v (@$obj){
-            push @res, $self->object_to_json($v) || $self->value_to_json($v);
+            my $from_obj = $self->object_to_json($v);
+            push @res, defined $from_obj ? $from_obj : $self->value_to_json($v);
         }
 
         --$depth;

--- a/t/e10_bignum.t
+++ b/t/e10_bignum.t
@@ -1,7 +1,7 @@
 
 use strict;
 use Test::More;
-BEGIN { plan tests => 6 };
+BEGIN { plan tests => 7 };
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = "JSON::backportPP"; }
 
@@ -37,5 +37,6 @@ isa_ok($num, 'Math::BigFloat');
 is("$num", '2.0000000000000000001');
 is($json->encode($num), '2.0000000000000000001');
 
+is($json->encode([Math::BigInt->new("0")]), '[0]', "zero bigint is 0 (the number), not '0' (the string)" );
 
 }


### PR DESCRIPTION
This PR fixes the RT#90319:encoding then decoding [Math::BigInt->new("0")] were giving ["0"] instead of [0].

This is because at some point a test was being done using || instead of defineness. "0" would be dejsonified into 0, which is correct, that is, defined, but false nevertheless. 

I replaced the || by defined(), and added a test. The whole testsuite works and the bug seems fixed. Let me know if you need anything else.

Thanks,
dams