### PR TITLE
Try load configuration from JSON::ConfigLocal module

### DIFF
--- a/lib/JSON.pm
+++ b/lib/JSON.pm
@@ -9,6 +9,15 @@ BEGIN { @JSON::ISA = 'Exporter' }
 @JSON::EXPORT = qw(from_json to_json jsonToObj objToJson encode_json decode_json);
 
 BEGIN {
+    local ($SIG{__DIE__}, $SIG{__WARN__}, $@, $!);
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
+    eval {
+        require JSON::ConfigLocal;
+    };
+}
+
+BEGIN {
     $JSON::VERSION = '2.94';
     $JSON::DEBUG   = 0 unless (defined $JSON::DEBUG);
     $JSON::DEBUG   = $ENV{ PERL_JSON_DEBUG } if exists $ENV{ PERL_JSON_DEBUG };


### PR DESCRIPTION
Do similar thing as Encode module. When JSON module is loading, before
applying any logic based on configuration parameters, it tries to load
JSON::ConfigLocal module which could set some system default values (like
json backend, etc...).

Encode module which is also part of core modules is doing same thing and
loads module named Encode::ConfigLocal. So for consistency is used name
JSON::ConfigLocal.