### PR TITLE
Test::Pod is required for testing

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,6 +52,9 @@ WriteMakefile(
     'PREREQ_PM'     => {
               'Test::More'  => 0,
     },
+    "TEST_REQUIRES" => {
+              'Test::Pod'   => "1.00",
+    },
     ( $ExtUtils::MakeMaker::VERSION >= 6.3002 ? ('LICENSE' => 'perl', ) : () ),
 
     ( $ExtUtils::MakeMaker::VERSION >= 6.46 ? (


### PR DESCRIPTION
Otherwise the following test will be skipped:

<pre>
t/00_pod.t ..................................... skipped: Test::Pod 1.00 required for testing POD
</pre>